### PR TITLE
Use `babel`'s built-in option manager for loading configs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "babel-core": "^6.0.0",
-    "babel-plugin-module-resolver": "^3.0.0-beta"
+    "babel-plugin-module-resolver": "^2.3.0"
   },
   "scripts": {
     "lint": "eslint src test",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "import"
   ],
   "dependencies": {
-    "find-babel-config": "^1.0.0",
     "resolve": "^1.1.7"
   },
   "devDependencies": {
+    "babel-core": "^6.0.0",
     "babel-jest": "^16.0.0",
     "babel-plugin-module-resolver": "^2.3.0",
     "eslint": "^3.3.0",
@@ -43,7 +43,8 @@
     "standard-version": "^3.0.0"
   },
   "peerDependencies": {
-    "babel-plugin-module-resolver": "^2.3.0"
+    "babel-core": "^6.0.0",
+    "babel-plugin-module-resolver": "^3.0.0-beta"
   },
   "scripts": {
     "lint": "eslint src test",

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,24 @@ function opts(file, config) {
 
 exports.interfaceVersion = 2;
 
+function getPlugins(file) {
+    try {
+        const manager = new OptionManager();
+        const result = manager.init({
+            babelrc: true,
+            filename: file,
+        });
+        return result.plugins;
+    } catch (err) {
+        // This error should only occur if something goes wrong with babel's
+        // internals. Dump it to console so people know what's going on,
+        // elsewise the error will simply be squelched in the calling code.
+        console.error('[eslint-import-resolver-babel-module]', err);
+        console.error('See: https://github.com/tleunen/eslint-import-resolver-babel-module/pull/28');
+        return [];
+    }
+}
+
 /**
  * Find the full path to 'source', given 'file' as a full reference path.
  *
@@ -30,12 +48,7 @@ exports.resolve = (source, file, options) => {
     if (resolve.isCore(source)) return { found: true, path: null };
 
     try {
-        const manager = new OptionManager();
-        const result = manager.init({
-            babelrc: true,
-            filename: file,
-        });
-        const instances = result.plugins.filter((plugin) => {
+        const instances = getPlugins(file).filter((plugin) => {
             const plug = OptionManager.memoisedPlugins.find(item =>
                 item.plugin === plugin[0]
             );

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,8 @@ function opts(file, config) {
 exports.interfaceVersion = 2;
 
 function getPlugins(file, target) {
-    const OptionManager = require('babel-core/lib/transformation/file/options/option-manager'); // eslint-disable-line
     try {
+        const OptionManager = require('babel-core').OptionManager; // eslint-disable-line
         const manager = new OptionManager();
         const result = manager.init({
             babelrc: true,

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const resolve = require('resolve');
 const mapModule = require('babel-plugin-module-resolver').mapModule;
 const targetPlugin = require('babel-plugin-module-resolver').default;
+const OptionManager = require('babel-core').OptionManager;
 
 function opts(file, config) {
     return Object.assign(
@@ -17,7 +18,6 @@ exports.interfaceVersion = 2;
 
 function getPlugins(file, target) {
     try {
-        const OptionManager = require('babel-core').OptionManager; // eslint-disable-line
         const manager = new OptionManager();
         const result = manager.init({
             babelrc: true,

--- a/src/index.js
+++ b/src/index.js
@@ -3,41 +3,11 @@
 const path = require('path');
 const resolve = require('resolve');
 const mapModule = require('babel-plugin-module-resolver').mapModule;
-const findBabelConfig = require('find-babel-config'); // eslint-disable-line
-
-function findModuleAliasConfig(conf) {
-    if (conf.plugins) {
-        return conf.plugins.find(p => p[0] === 'module-resolver' || p[0] === 'babel-plugin-module-resolver');
-    }
-    return null;
-}
-
-function getPluginOpts(config) {
-    const env = process.env.BABEL_ENV || process.env.NODE_ENV || 'development';
-
-    if (config) {
-        const pluginConfig = findModuleAliasConfig(config);
-
-        if (config.env && config.env[env]) {
-            const envPluginConfig = findModuleAliasConfig(config.env[env]);
-            if (envPluginConfig) {
-                if (pluginConfig) {
-                    return {
-                        root: [].concat(pluginConfig[1].root, envPluginConfig[1].root),
-                        alias: Object.assign({}, pluginConfig[1].alias, envPluginConfig[1].alias),
-                    };
-                }
-                return envPluginConfig[1];
-            }
-        }
-
-        if (pluginConfig) {
-            return pluginConfig[1];
-        }
-    }
-
-    return {};
-}
+const targetPlugin = require('babel-plugin-module-resolver').default;
+const OptionManager =
+    require('babel-core/lib/transformation/file/options/option-manager');
+const buildConfigChain =
+    require('babel-core/lib/transformation/file/options/build-config-chain');
 
 function opts(file, config) {
     return Object.assign(
@@ -61,20 +31,28 @@ exports.interfaceVersion = 2;
 exports.resolve = (source, file, options) => {
     if (resolve.isCore(source)) return { found: true, path: null };
 
-    const babelConfig = findBabelConfig.sync(path.dirname(file));
-    const babelrcPath = babelConfig.file;
-    const config = babelConfig.config;
-    let cwd = babelrcPath
-        ? path.dirname(babelrcPath)
-        : process.cwd();
-
     try {
-        const pluginOpts = getPluginOpts(config);
-        if (pluginOpts.cwd !== 'babelrc') {
-            cwd = pluginOpts.cwd || cwd;
-        }
-
-        const src = mapModule(source, file, pluginOpts, cwd) || source;
+        const manager = new OptionManager();
+        const babelOptions = {
+            babelrc: true,
+            filename: file,
+        };
+        const configs = buildConfigChain(babelOptions);
+        configs.forEach(x => manager.mergeOptions(x));
+        manager.normaliseOptions(babelOptions);
+        const cwd = configs.length > 0 ? configs[0].dirname : process.cwd();
+        const instances = manager.options.plugins.filter((plugin) => {
+            const plug = OptionManager.memoisedPlugins.find(item =>
+                item.plugin === plugin[0]
+            );
+            return plug && plug.container === targetPlugin;
+        });
+        const pluginOpts = instances.reduce((config, plugin) => ({
+            cwd: plugin.cwd || config.cwd,
+            root: config.root.concat(plugin[1] ? plugin[1].root : []),
+            alias: Object.assign(config.alias, plugin[1] ? plugin[1].alias : {}),
+        }), { root: [], alias: {}, cwd });
+        const src = mapModule(source, file, pluginOpts, pluginOpts.cwd) || source;
         return {
             found: true,
             path: resolve.sync(src, opts(file, options)),

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -1,6 +1,7 @@
 {
   "plugins": [
     ["module-resolver", {
+      "cwd": "./test",
       "alias": {
         "components": "./examples/components",
         "underscore": "npm:lodash"

--- a/test/examples/components/sub/envonly/.babelrc
+++ b/test/examples/components/sub/envonly/.babelrc
@@ -3,6 +3,7 @@
     "test": {
       "plugins": [
         ["module-resolver", {
+          "cwd": "./test/examples/components/sub/envonly",
           "alias": {
             "subsub": "../sub"
           }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -109,7 +109,7 @@ describe('eslint-import-resolver-module-resolver', () => {
             });
         });
 
-        describe('when ony specific env is available', () => {
+        describe.only('when ony specific env is available', () => {
             it('should return `false` when the mapping doesn\'t exist in "env"', () => {
                 const oldEnv = process.env.NODE_ENV;
                 process.env.NODE_ENV = 'development';

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -109,7 +109,7 @@ describe('eslint-import-resolver-module-resolver', () => {
             });
         });
 
-        describe.only('when ony specific env is available', () => {
+        describe('when ony specific env is available', () => {
             it('should return `false` when the mapping doesn\'t exist in "env"', () => {
                 const oldEnv = process.env.NODE_ENV;
                 process.env.NODE_ENV = 'development';

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,7 @@
 
 const path = require('path');
 const resolverPlugin = require('../src/index');
-const OptionManager = require('babel-core/lib/transformation/file/options/option-manager');
+const OptionManager = require('babel-core').OptionManager;
 
 const opts = {};
 const extensionOpts = { extensions: ['.js', '.jsx'] };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,7 @@
 
 const path = require('path');
 const resolverPlugin = require('../src/index');
+const OptionManager = require('babel-core/lib/transformation/file/options/option-manager');
 
 const opts = {};
 const extensionOpts = { extensions: ['.js', '.jsx'] };
@@ -132,6 +133,25 @@ describe('eslint-import-resolver-module-resolver', () => {
 
                 process.env.NODE_ENV = oldEnv;
             });
+        });
+    });
+
+    describe('babel internals', () => {
+        let oldInit;
+
+        beforeEach(() => {
+            oldInit = OptionManager.prototype.init;
+        });
+        afterEach(() => {
+            OptionManager.prototype.init = oldInit;
+        });
+
+        it('should survive babel blowing up', () => {
+            OptionManager.prototype.init = () => { throw new TypeError(); };
+            expect(resolverPlugin.resolve('underscore', path.resolve('./test/examples/file1'), opts))
+                .toEqual({
+                    found: false,
+                });
         });
     });
 });


### PR DESCRIPTION
There is an issue if you configure this plugin anywhere outside of your `.babelrc`. For example, if you have:

```json
{
  "presets": ["my-preset"]
}
```

And in your preset you have this plugin configured, then this plugin will fail to find that configuration value. It will also fail if you have multiple `.babelrc`'s and the configuration is defined up the tree somewhere (as is also possible).

By leveraging babel's built-in option manager for doing all the heavy lifting we avoid these pitfalls. No dealing with environment settings or checking the shape of the configuration object. It's also a lot less code and coverage goes to the moon 🚀 .

The only minor concern is that it leverages a bit of babel's "inner" workings and if they change that then this could break but that's no better than how it is now really.

Everything. Just. Works.™