### PR TITLE
Revert "Use `babel`'s built-in option manager for loading configs."

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "import"
   ],
   "dependencies": {
+    "find-babel-config": "^1.0.0",
     "resolve": "^1.1.7"
   },
   "devDependencies": {
-    "babel-core": "^6.0.0",
     "babel-jest": "^16.0.0",
     "babel-plugin-module-resolver": "^2.3.0",
     "eslint": "^3.3.0",
@@ -43,7 +43,6 @@
     "standard-version": "^3.0.0"
   },
   "peerDependencies": {
-    "babel-core": "^6.0.0",
     "babel-plugin-module-resolver": "^2.3.0"
   },
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,41 @@
 const path = require('path');
 const resolve = require('resolve');
 const mapModule = require('babel-plugin-module-resolver').mapModule;
-const targetPlugin = require('babel-plugin-module-resolver').default;
-const OptionManager = require('babel-core').OptionManager;
+const findBabelConfig = require('find-babel-config'); // eslint-disable-line
+
+function findModuleAliasConfig(conf) {
+    if (conf.plugins) {
+        return conf.plugins.find(p => p[0] === 'module-resolver' || p[0] === 'babel-plugin-module-resolver');
+    }
+    return null;
+}
+
+function getPluginOpts(config) {
+    const env = process.env.BABEL_ENV || process.env.NODE_ENV || 'development';
+
+    if (config) {
+        const pluginConfig = findModuleAliasConfig(config);
+
+        if (config.env && config.env[env]) {
+            const envPluginConfig = findModuleAliasConfig(config.env[env]);
+            if (envPluginConfig) {
+                if (pluginConfig) {
+                    return {
+                        root: [].concat(pluginConfig[1].root, envPluginConfig[1].root),
+                        alias: Object.assign({}, pluginConfig[1].alias, envPluginConfig[1].alias),
+                    };
+                }
+                return envPluginConfig[1];
+            }
+        }
+
+        if (pluginConfig) {
+            return pluginConfig[1];
+        }
+    }
+
+    return {};
+}
 
 function opts(file, config) {
     return Object.assign(
@@ -15,29 +48,6 @@ function opts(file, config) {
 }
 
 exports.interfaceVersion = 2;
-
-function getPlugins(file, target) {
-    try {
-        const manager = new OptionManager();
-        const result = manager.init({
-            babelrc: true,
-            filename: file,
-        });
-        return result.plugins.filter((plugin) => {
-            const plug = OptionManager.memoisedPlugins.find(item =>
-                item.plugin === plugin[0]
-            );
-            return plug && plug.container === target;
-        });
-    } catch (err) {
-        // This error should only occur if something goes wrong with babel's
-        // internals. Dump it to console so people know what's going on,
-        // elsewise the error will simply be squelched in the calling code.
-        console.error('[eslint-import-resolver-babel-module]', err);
-        console.error('See: https://github.com/tleunen/eslint-import-resolver-babel-module/pull/28');
-        return [];
-    }
-}
 
 /**
  * Find the full path to 'source', given 'file' as a full reference path.
@@ -51,15 +61,20 @@ function getPlugins(file, target) {
 exports.resolve = (source, file, options) => {
     if (resolve.isCore(source)) return { found: true, path: null };
 
+    const babelConfig = findBabelConfig.sync(path.dirname(file));
+    const babelrcPath = babelConfig.file;
+    const config = babelConfig.config;
+    let cwd = babelrcPath
+        ? path.dirname(babelrcPath)
+        : process.cwd();
+
     try {
-        const instances = getPlugins(file, targetPlugin);
-        const pluginOpts = instances.reduce((config, plugin) => ({
-            cwd: plugin[1] && plugin[1].cwd ? plugin[1].cwd : config.cwd,
-            root: config.root.concat(plugin[1] && plugin[1].root ? plugin[1].root : []),
-            alias: Object.assign(config.alias, plugin[1] ? plugin[1].alias : {}),
-        }), { root: [], alias: {}, cwd: process.cwd() });
-        pluginOpts.cwd = path.resolve(pluginOpts.cwd);
-        const src = mapModule(source, file, pluginOpts, pluginOpts.cwd) || source;
+        const pluginOpts = getPluginOpts(config);
+        if (pluginOpts.cwd !== 'babelrc') {
+            cwd = pluginOpts.cwd || cwd;
+        }
+
+        const src = mapModule(source, file, pluginOpts, cwd) || source;
         return {
             found: true,
             path: resolve.sync(src, opts(file, options)),

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -1,7 +1,6 @@
 {
   "plugins": [
     ["module-resolver", {
-      "cwd": "./test",
       "alias": {
         "components": "./examples/components",
         "underscore": "npm:lodash"

--- a/test/examples/components/sub/envonly/.babelrc
+++ b/test/examples/components/sub/envonly/.babelrc
@@ -3,7 +3,6 @@
     "test": {
       "plugins": [
         ["module-resolver", {
-          "cwd": "./test/examples/components/sub/envonly",
           "alias": {
             "subsub": "../sub"
           }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,6 @@
 
 const path = require('path');
 const resolverPlugin = require('../src/index');
-const OptionManager = require('babel-core').OptionManager;
 
 const opts = {};
 const extensionOpts = { extensions: ['.js', '.jsx'] };
@@ -133,25 +132,6 @@ describe('eslint-import-resolver-module-resolver', () => {
 
                 process.env.NODE_ENV = oldEnv;
             });
-        });
-    });
-
-    describe('babel internals', () => {
-        let oldInit;
-
-        beforeEach(() => {
-            oldInit = OptionManager.prototype.init;
-        });
-        afterEach(() => {
-            OptionManager.prototype.init = oldInit;
-        });
-
-        it('should survive babel blowing up', () => {
-            OptionManager.prototype.init = () => { throw new TypeError(); };
-            expect(resolverPlugin.resolve('underscore', path.resolve('./test/examples/file1'), opts))
-                .toEqual({
-                    found: false,
-                });
         });
     });
 });


### PR DESCRIPTION
Reverts tleunen/eslint-import-resolver-babel-module#28

@izaakschroeder Reverting your PR because it had side effects when running in an editor because the cwd is not the same. In an editor, the cwd is the directory of the opened file. That's also why we fetched the babelrc file and use it as a cwd.

I don't have time right now to investigate further and see if we can get something from Babel for that, so I'm reverting to fix the issue for everyone.