### PR TITLE
Fixes issue where Sublime Text 3 can’t resolve absolute imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,7 @@ exports.resolve = (source, file, options = {}) => {
           ...options,
           extensions,
           basedir: path.dirname(file),
+          paths: options.paths.map((path) => (`${projectRootDir}/${path}`)),
         },
       ),
     };

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ exports.resolve = (source, file, options = {}) => {
           ...options,
           extensions,
           basedir: path.dirname(file),
-          paths: options.paths.map((path) => (`${projectRootDir}/${path}`)),
+          paths: options.paths.map(apath => (`${projectRootDir}/${apath}`)),
         },
       ),
     };


### PR DESCRIPTION
.babelrc
```
{
	"presets": ["react-native"],
	"retainLines": true,
	"plugins": [
		["module-resolver", {
			"root": ["./resources", "./app"],
			"paths": ["./resources", "./app"],
			'cwd': "babelrc"
		}]
	]
}
```

.eslintrc
```
{ ...
  "parser": "babel-eslint",
  "settings": {
    "import/resolver": {
			"babel-module": {
				"root": ["./resources", "./app"],
				"paths": ["./resources", "./app"],
				'cwd': "babelrc"
			}
    }
  },
  ...
}
```

Signin.js
```
import Page from 'common/Page';
...
```

Import works, but eslinting in Sublime Text 3 fails without this change. 
