### PR TITLE
adding support for eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "test": "jest --coverage",
     "test:suite": "jest",
     "test:watch": "jest --watch",
-    "prepublish": "npm run compile",
+    "prepare": "npm run compile",
+    "preinstall": "npm run compile",
     "release": "standard-version"
   },
   "jest": {

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,21 @@ exports.resolve = (source, file, opts) => {
       root: config.root.concat(plugin[1] && plugin[1].root ? plugin[1].root : []),
       alias: Object.assign(config.alias, plugin[1] ? plugin[1].alias : {}),
       extensions: plugin[1] && plugin[1].extensions ? plugin[1].extensions : config.extensions,
-    }), { root: [], alias: {}, cwd: projectRootDir });
+    }), {
+      // if .babelrc doesn't exist, try to get the configuration information from the `opts`,
+      // which gets defined by the eslint configuration file.
+      // e.g. in .eslintrc file
+      // "import/resolver": {
+      //   "babel-module": {
+      //     "root": ["./src"],
+      //     "extensions": [".js", ".jsx"]
+      //   }
+      // }
+      cwd: options.cwd || projectRootDir,
+      root: options.root || [],
+      alias: options.alias || {},
+      extensions: options.extensions || ['.js'], // .js is the default option
+    });
 
     const manipulatedOpts = babelModuleResolver.manipulatePluginOptions(pluginOpts);
 


### PR DESCRIPTION
support configuration from `.eslintrc` setting. It's useful if a project doesn't have `.babelrc` file
e.g. in `.eslintrc` file
```
"import/resolver": {
  "babel-module": {
    "root": ["./src"],
    "extensions": [".js", ".jsx"]
  }
}
```