### PR TITLE
fix: Fix resolution when using a custom cwd

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,9 +58,6 @@ exports.resolve = (source, file, opts) => {
       extensions: plugin[1] && plugin[1].extensions ? plugin[1].extensions : config.extensions,
     }), { root: [], alias: {}, cwd: projectRootDir });
 
-
-    normalizeOptions(pluginOpts, file);
-
     const babelState = {
       file: {
         opts: {
@@ -69,6 +66,8 @@ exports.resolve = (source, file, opts) => {
       },
       opts: pluginOpts,
     };
+
+    normalizeOptions(pluginOpts, babelState);
     const src = getRealPath(source, babelState);
 
     const extensions = options.extensions || pluginOpts.extensions;


### PR DESCRIPTION
`normalizeOptions` actually requires the babel state, instead of the filename.

Changing that will normalize the options and the cwd, thus transforming the custom `babelrc` value into the right path.

This will fix #43 