### PR TITLE
fix: Fix the custom babel cwd in an editor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ exports.resolve = (source, file, opts) => {
       opts: pluginOpts,
     };
 
-    normalizeOptions(pluginOpts, babelState);
+    normalizeOptions(babelState.opts, babelState.file);
     const src = getRealPath(source, babelState);
 
     const extensions = options.extensions || pluginOpts.extensions;


### PR DESCRIPTION
Previous fix was incorrect/incomplete.

This sends the right data to `normalizeOptions`.