### PR TITLE
feat: Add support for Babel 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "standard-version": "^4.0.0"
   },
   "peerDependencies": {
-    "babel-core": "^6.0.0",
+    "babel-core": "^6.0.0 || >7.0.0-alpha",
     "babel-plugin-module-resolver": ">3.0.0-beta"
   },
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,12 @@ function getPlugins(file, target) {
       babelrc: true,
       filename: file,
     });
-    
+
     // Babel 7.0.0
     if (!OptionManager.memoisedPlugins) {
-      return result.plugins.filter(function (plugin) {
-        var plug = plugin[0] || plugin;
-        return plug.key.indexOf('/babel-plugin-module-resolver/') > -1;
+      return result.plugins.filter((plugin) => {
+        const plug = plugin[0] || plugin;
+        return plug.key.indexOf('babel-plugin-module-resolver') > -1;
       });
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,16 @@ function getPlugins(file, target) {
       babelrc: true,
       filename: file,
     });
+    
+    // Babel 7.0.0
+    if (!OptionManager.memoisedPlugins) {
+      return result.plugins.filter(function (plugin) {
+        var plug = plugin[0] || plugin;
+        return plug.key.indexOf('/babel-plugin-module-resolver/') > -1;
+      });
+    }
 
+    // Babel 6.0.0
     return result.plugins.filter((plugin) => {
       const plug = OptionManager.memoisedPlugins.find(item => item.plugin === plugin[0]);
 


### PR DESCRIPTION
`memoisedPlugins` does not exists in Babel 7.0.0 
So I'm traversing plugins by its keys which contain `/babel-plugin-module-resolver/` substring:

Plugin now has such shape: 
```js
Plugin {
  key: '/Volumes/npm_ram_disk/node_modules/babel-plugin-module-resolver/lib/index.js',
  manipulateOptions: undefined,
  post: undefined,
  pre: [Function: pre],
  visitor:
   { Program: { enter: [Object] },
     _exploded: true,
     _verified: true } }
```

Tested locally - worked perfectly. This PR backward compatible with babel 6.