### PR TITLE
Support latest babel 7 only

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["env", {
+    ["@babel/env", {
       "targets": {
         "node": 6
       },
@@ -9,6 +9,6 @@
     }]
   ],
   "plugins": [
-    ["transform-object-rest-spread", { "useBuiltIns": true }]
+    ["@babel/proposal-object-rest-spread", { "useBuiltIns": true }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -36,12 +36,13 @@
     "resolve": "^1.4.0"
   },
   "devDependencies": {
-    "babel-cli": "^7.0.0-beta.2",
-    "babel-core": "^7.0.0-beta.2",
+    "@babel/cli": "^7.0.0-beta.34",
+    "@babel/core": "^7.0.0-beta.34",
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.34",
+    "@babel/preset-env": "^7.0.0-beta.34",
+    "babel-core": "^7.0.0-0",
     "babel-jest": "^21.2.0",
-    "babel-plugin-module-resolver": "^3.0.0-beta.0",
-    "babel-plugin-transform-object-rest-spread": "^7.0.0-beta.2",
-    "babel-preset-env": "^2.0.0-beta.2",
+    "babel-plugin-module-resolver": "^3.0.0",
     "eslint": "^4.8.0",
     "eslint-config-airbnb-base": "^12.0.2",
     "eslint-plugin-import": "^2.7.0",
@@ -50,19 +51,14 @@
     "standard-version": "^4.2.0"
   },
   "peerDependencies": {
-    "babel-core": "^6.0.0 || >7.0.0-alpha",
-    "babel-plugin-module-resolver": "^3.0.0-beta"
+    "@babel/core": "^7.0.0-0",
+    "babel-plugin-module-resolver": "^3.0.0"
   },
   "scripts": {
     "lint": "eslint src test",
     "compile": "babel src --out-dir lib",
-    "babel:clean": "rimraf node_modules/babel-cli node_modules/babel-core node_modules/babel-plugin-transform-object-rest-spread",
-    "babel:6": "npm run babel:clean && npm i babel-cli@^6 babel-core@^6 babel-plugin-transform-object-rest-spread@^6",
-    "babel:7": "npm run babel:clean && npm i babel-cli@^7.0.0-beta babel-core@^7.0.0-beta babel-plugin-transform-object-rest-spread@^7.0.0-beta",
-    "test:babel:6": "npm run babel:6 && npm run test:suite",
-    "test:babel:7": "npm run babel:7 && npm run test:suite --coverage",
     "pretest": "npm run lint",
-    "test": "npm run test:babel:6 && npm run test:babel:7",
+    "test": "npm run test:suite --coverage",
     "test:suite": "jest",
     "test:watch": "jest --watch",
     "prepare": "npm run compile",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const path = require('path');
 const resolve = require('resolve');
 const pkgUp = require('pkg-up');
 const { resolvePath } = require('babel-plugin-module-resolver');
-const { OptionManager } = require('babel-core');
+const { OptionManager } = require('@babel/core');
 
 function getPlugins(file) {
   try {
@@ -12,19 +12,7 @@ function getPlugins(file) {
       filename: file,
     });
 
-    // Babel 7.0.0
-    if (!OptionManager.memoisedPlugins) {
-      return result.plugins.filter((plugin) => {
-        const plug = plugin[0] || plugin;
-        return plug.key.indexOf('babel-plugin-module-resolver') > -1;
-      });
-    }
-
-    // Babel 6.0.0
-    return result.plugins.filter((plugin) => {
-      const plug = OptionManager.memoisedPlugins.find(item => item.plugin === plugin[0]);
-      return plug && plug.plugin && plug.plugin.key === 'module-resolver';
-    });
+    return result.plugins.filter(plugin => plugin.key === 'module-resolver');
   } catch (err) {
     // This error should only occur if something goes wrong with babel's
     // internals. Dump it to console so people know what's going on,
@@ -33,6 +21,20 @@ function getPlugins(file) {
     console.error('See: https://github.com/tleunen/eslint-import-resolver-babel-module/pull/34');
     return [];
   }
+}
+
+function getPluginOptions(file, defaultOptions) {
+  const instances = getPlugins(file);
+
+  return instances.reduce(
+    (config, plugin) => ({
+      cwd: plugin.options.cwd || config.cwd,
+      root: config.root.concat(plugin.options.root || []),
+      alias: Object.assign(config.alias, plugin.options.alias || {}),
+      extensions: plugin.options.extensions || config.extensions,
+    }),
+    defaultOptions,
+  );
 }
 
 function stripWebpack(src) {
@@ -55,6 +57,8 @@ function stripWebpack(src) {
 
 exports.interfaceVersion = 2;
 
+const defaultExtensions = ['.js', '.jsx', '.es', '.es6', '.mjs'];
+
 /**
  * Find the full path to 'source', given 'file' as a full reference path.
  *
@@ -71,15 +75,8 @@ exports.resolve = (source, file, opts) => {
   const projectRootDir = path.dirname(pkgUp.sync(file));
 
   try {
-    const instances = getPlugins(file);
-
-    const pluginOpts = instances.reduce(
-      (config, plugin) => ({
-        cwd: plugin[1] && plugin[1].cwd ? plugin[1].cwd : config.cwd,
-        root: config.root.concat(plugin[1] && plugin[1].root ? plugin[1].root : []),
-        alias: Object.assign(config.alias, plugin[1] ? plugin[1].alias : {}),
-        extensions: plugin[1] && plugin[1].extensions ? plugin[1].extensions : config.extensions,
-      }),
+    const pluginOptions = getPluginOptions(
+      file,
       {
         // if .babelrc doesn't exist, try to get the configuration information from `options`,
         // which gets defined by the eslint configuration file.
@@ -93,14 +90,14 @@ exports.resolve = (source, file, opts) => {
         cwd: options.cwd || projectRootDir,
         root: options.root || [],
         alias: options.alias || {},
-        extensions: options.extensions || ['.js', '.jsx', '.es', '.es6', '.mjs'],
+        extensions: options.extensions || defaultExtensions,
       },
     );
 
     const finalSource = stripWebpack(source);
-    const src = resolvePath(finalSource, file, pluginOpts);
+    const src = resolvePath(finalSource, file, pluginOptions);
 
-    const extensions = options.extensions || pluginOpts.extensions;
+    const extensions = options.extensions || pluginOptions.extensions;
 
     return {
       found: true,

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -4,13 +4,13 @@
       "root": ["./test/examples/**"],
       "alias": {
         "components": "./test/examples/components",
-        "old-bcore": "babel-core"
+        "babel-plugin": "babel-plugin-module-resolver"
       },
       "extensions": [".js", ".customExt"]
     }]
   ],
   "env": {
-    "test": {
+    "testenv": {
       "plugins": [
         ["babel-plugin-module-resolver", {
           "alias": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,6 @@
 'use strict';
 
 const path = require('path');
-const { OptionManager } = require('babel-core');
 const resolverPlugin = require('../src/index');
 
 const opts = {};
@@ -17,10 +16,10 @@ describe('eslint-import-resolver-module-resolver', () => {
   });
 
   it('should return `true` when mapped to a npm module', () => {
-    expect(resolverPlugin.resolve('old-bcore', path.resolve('./test/examples/file1'), opts))
+    expect(resolverPlugin.resolve('babel-plugin', path.resolve('./test/examples/file1'), opts))
       .toEqual({
         found: true,
-        path: path.resolve(__dirname, '../node_modules/babel-core/index.js'),
+        path: path.resolve(__dirname, '../node_modules/babel-plugin-module-resolver/lib/index.js'),
       });
   });
 
@@ -141,7 +140,7 @@ describe('eslint-import-resolver-module-resolver', () => {
 
       it('should return `true` when the mapping exists in the "env"', () => {
         const oldEnv = process.env.NODE_ENV;
-        process.env.NODE_ENV = 'test';
+        process.env.NODE_ENV = 'testenv';
 
         expect(resolverPlugin.resolve('subsub/c2', path.resolve('./test/examples/components/c1'), opts))
           .toEqual({
@@ -166,7 +165,7 @@ describe('eslint-import-resolver-module-resolver', () => {
 
       it('should return `true` when the mapping exists in the "env"', () => {
         const oldEnv = process.env.NODE_ENV;
-        process.env.NODE_ENV = 'test';
+        process.env.NODE_ENV = 'testenv';
 
         expect(resolverPlugin.resolve('subsub/c2', path.resolve('./test/examples/components/sub/envonly/yo'), opts))
           .toEqual({
@@ -176,34 +175,6 @@ describe('eslint-import-resolver-module-resolver', () => {
 
         process.env.NODE_ENV = oldEnv;
       });
-    });
-  });
-
-  describe('babel internals', () => {
-    let oldInit;
-    let error;
-
-    beforeEach(() => {
-      oldInit = OptionManager.prototype.init;
-      // eslint-disable-next-line prefer-destructuring
-      error = console.error;
-    });
-    afterEach(() => {
-      OptionManager.prototype.init = oldInit;
-      console.error = error;
-    });
-
-    it('should survive babel blowing up', () => {
-      console.error = jest.fn();
-
-      OptionManager.prototype.init = undefined;
-
-      expect(resolverPlugin.resolve('underscore', path.resolve('./test/examples/file1'), opts))
-        .toEqual({
-          found: false,
-        });
-
-      expect(console.error).toBeCalled();
     });
   });
 });


### PR DESCRIPTION
This drops babel 6 as babel 7 now has also different package names which makes it rather complicated to support both.

This fixes several issues:
 - The plugins received from OptionManager are now classes and not arrays and have a prop `options` 
- The plugin key that the resolver was checking in the babel 7 case was wrong it is now `module-resolver` see here https://github.com/tleunen/babel-plugin-module-resolver/blob/master/src/index.js#L25
- The tests are broken, because jest by default sets the env to "test" which was interfering with the test that tested different environments.
- The babel internal test does not work as internals are not exposed this way anymore

This is basically the same as #76 with fixed tests.