### PR TITLE
Remove babel 7 to release v4 with babel 6 only

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "resolve": "^1.4.0"
   },
   "devDependencies": {
-    "babel-cli": "^7.0.0-beta.2",
-    "babel-core": "^7.0.0-beta.2",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
     "babel-jest": "^21.2.0",
     "babel-plugin-module-resolver": "^3.0.0-beta.0",
-    "babel-plugin-transform-object-rest-spread": "^7.0.0-beta.2",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^2.0.0-beta.2",
     "eslint": "^4.8.0",
     "eslint-config-airbnb-base": "^12.0.2",
@@ -50,7 +50,7 @@
     "standard-version": "^4.2.0"
   },
   "peerDependencies": {
-    "babel-core": "^6.0.0 || >7.0.0-alpha",
+    "babel-core": "^6.0.0",
     "babel-plugin-module-resolver": "^3.0.0-beta"
   },
   "scripts": {
@@ -58,11 +58,9 @@
     "compile": "babel src --out-dir lib",
     "babel:clean": "rimraf node_modules/babel-cli node_modules/babel-core node_modules/babel-plugin-transform-object-rest-spread",
     "babel:6": "npm run babel:clean && npm i babel-cli@^6 babel-core@^6 babel-plugin-transform-object-rest-spread@^6",
-    "babel:7": "npm run babel:clean && npm i babel-cli@^7.0.0-beta babel-core@^7.0.0-beta babel-plugin-transform-object-rest-spread@^7.0.0-beta",
     "test:babel:6": "npm run babel:6 && npm run test:suite",
-    "test:babel:7": "npm run babel:7 && npm run test:suite --coverage",
     "pretest": "npm run lint",
-    "test": "npm run test:babel:6 && npm run test:babel:7",
+    "test": "npm run test:babel:6",
     "test:suite": "jest",
     "test:watch": "jest --watch",
     "prepare": "npm run compile",

--- a/src/index.js
+++ b/src/index.js
@@ -12,15 +12,6 @@ function getPlugins(file) {
       filename: file,
     });
 
-    // Babel 7.0.0
-    if (!OptionManager.memoisedPlugins) {
-      return result.plugins.filter((plugin) => {
-        const plug = plugin[0] || plugin;
-        return plug.key.indexOf('babel-plugin-module-resolver') > -1;
-      });
-    }
-
-    // Babel 6.0.0
     return result.plugins.filter((plugin) => {
       const plug = OptionManager.memoisedPlugins.find(item => item.plugin === plugin[0]);
       return plug && plug.plugin && plug.plugin.key === 'module-resolver';


### PR DESCRIPTION
I removed all support for babel 7 since it was broken anyway. I'll release v4 with babel 6 only and then a v5.beta with babel 7, from #78.