### PR TITLE
feat: Add monorepo support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,13 @@ const pkgUp = require('pkg-up');
 const { resolvePath } = require('babel-plugin-module-resolver');
 const { OptionManager } = require('@babel/core');
 
-function getPlugins(file) {
+function getPlugins(file, cwd) {
   try {
     const manager = new OptionManager();
     const result = manager.init({
       babelrc: true,
       filename: file,
+      cwd,
     });
 
     return result.plugins.filter(plugin => plugin.key === 'module-resolver');
@@ -23,8 +24,8 @@ function getPlugins(file) {
   }
 }
 
-function getPluginOptions(file, defaultOptions) {
-  const instances = getPlugins(file);
+function getPluginOptions(file, cwd, defaultOptions) {
+  const instances = getPlugins(file, cwd);
 
   return instances.reduce(
     (config, plugin) => ({
@@ -83,6 +84,7 @@ exports.resolve = (source, file, opts) => {
   try {
     const pluginOptions = getPluginOptions(
       file,
+      projectRootDir,
       {
         // if .babelrc doesn't exist, try to get the configuration information from `options`,
         // which gets defined by the eslint configuration file.

--- a/test/examples/monorepo/my-lib/.babelrc
+++ b/test/examples/monorepo/my-lib/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    ["module-resolver", {
+      "alias": {
+        "~": "./src"
+      }
+    }]
+  ]
+}

--- a/test/examples/monorepo/my-lib/package.json
+++ b/test/examples/monorepo/my-lib/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "my-lib",
+  "version": "1.0.0-test.0",
+  "description": "Imagine a monorepo",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -193,4 +193,14 @@ describe('eslint-import-resolver-module-resolver', () => {
       });
     });
   });
+
+  describe('usage in a monorepo', () => {
+    it('should return `true` when mapped to a file', () => {
+      expect(resolverPlugin.resolve('~/item', path.resolve('./test/examples/monorepo/my-lib/src/item'), extensionOpts))
+        .toEqual({
+          found: true,
+          path: path.resolve(__dirname, './examples/monorepo/my-lib/src/item.js'),
+        });
+    });
+  });
 });


### PR DESCRIPTION
Passes the correct cwd to babel's OptionManager to determine the babelrc location.

Fixes #100