### PR TITLE
chore: Update babel-plugin-module-resolver peerdep to allow v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0",
-    "babel-plugin-module-resolver": "^3.0.0"
+    "babel-plugin-module-resolver": "^4.0.0"
   },
   "scripts": {
     "lint": "eslint src test",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0",
-    "babel-plugin-module-resolver": "^4.0.0"
+    "babel-plugin-module-resolver": "^3.0.0 || ^4.0.0"
   },
   "scripts": {
     "lint": "eslint src test",


### PR DESCRIPTION
Since babel-plugin-module-resolver v4 is released, the peer dependency should be updated accordingly.
Please review, whether ^3.0.0 should be "or"ed too, and whether there are any compatibility issues. I have not noticed any so far, and the diff between 3 and 4 is also very minor.