### PR TITLE
Allow early exit on existing directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ And see [babel-plugin-module-resolver][babel-plugin-module-resolver] to know how
 }
 ```
 
+## Directory Imports
+
+Some babel plugins like [babel-plugin-import-directory](https://github.com/Anmo/babel-plugin-import-directory) or [babel-plugin-wildcard](https://github.com/vihanb/babel-plugin-wildcard) allow to import directories (i.e. each file inside a directory) as an object. In order to support this, you can activate the `allowExistingDirectories` option as follows:
+
+```
+"settings": {
+  "import/resolver": {
+    "babel-module": { allowExistingDirectories: true }
+  }
+}
+```
+
+Now when you import a directory like this, the ESLint plugin won't complain and recognize the existing directory:
+
+```
+import * as Items from './dir';
+```
+
 ## License
 
 MIT, see [LICENSE.md](/LICENSE.md) for details.

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const resolve = require('resolve');
 const pkgUp = require('pkg-up');
 const { resolvePath } = require('babel-plugin-module-resolver');
 const { OptionManager } = require('@babel/core');
+const fs = require('fs');
 
 function getPlugins(file, cwd, babelOptions) {
   try {
@@ -109,6 +110,10 @@ exports.resolve = (source, file, opts) => {
     const finalSource = stripWebpack(source, pluginOptions.alias);
     const resolvePathFunc = pluginOptions.resolvePath || resolvePath;
     const src = resolvePathFunc(finalSource, file, pluginOptions);
+    const absoluteSrc = path.join(path.dirname(file), src)
+    if (options.allowExistingDirectories && fs.existsSync(absoluteSrc)) {
+      return { found: true, path: absoluteSrc }
+    }
 
     const extensions = options.extensions || pluginOptions.extensions;
 

--- a/src/index.js
+++ b/src/index.js
@@ -110,9 +110,10 @@ exports.resolve = (source, file, opts) => {
     const finalSource = stripWebpack(source, pluginOptions.alias);
     const resolvePathFunc = pluginOptions.resolvePath || resolvePath;
     const src = resolvePathFunc(finalSource, file, pluginOptions);
-    const absoluteSrc = path.join(path.dirname(file), src)
+    const absoluteSrc = path.join(path.dirname(file), src);
+
     if (options.allowExistingDirectories && fs.existsSync(absoluteSrc)) {
-      return { found: true, path: absoluteSrc }
+      return { found: true, path: absoluteSrc };
     }
 
     const extensions = options.extensions || pluginOptions.extensions;

--- a/src/index.js
+++ b/src/index.js
@@ -112,10 +112,7 @@ exports.resolve = (source, file, opts) => {
     const src = resolvePathFunc(finalSource, file, pluginOptions);
     const absoluteSrc = path.join(path.dirname(file), src);
 
-    if (options.allowExistingDirectories
-      && fs.existsSync(absoluteSrc)
-      && fs.lstatSync(absoluteSrc).isDirectory()
-    ) {
+    if (options.allowExistingDirectories && fs.existsSync(absoluteSrc)) {
       return { found: true, path: absoluteSrc };
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,10 @@ exports.resolve = (source, file, opts) => {
     const src = resolvePathFunc(finalSource, file, pluginOptions);
     const absoluteSrc = path.join(path.dirname(file), src);
 
-    if (options.allowExistingDirectories && fs.existsSync(absoluteSrc)) {
+    if (options.allowExistingDirectories
+      && fs.existsSync(absoluteSrc)
+      && fs.lstatSync(absoluteSrc).isDirectory()
+    ) {
       return { found: true, path: absoluteSrc };
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -203,4 +203,14 @@ describe('eslint-import-resolver-module-resolver', () => {
         });
     });
   });
+
+  describe('allowExistingDirectories', () => {
+    it('should return `true` when directory exists', () => {
+      expect(resolverPlugin.resolve('components/sub', path.resolve('./test/examples/components/sub/c1'), { ...opts, allowExistingDirectories: true }))
+        .toEqual({
+          found: true,
+          path: `${path.resolve(__dirname, './examples/components/sub')}/`,
+        });
+    });
+  });
 });


### PR DESCRIPTION
Some babel plugins allow to import from directories:
https://www.npmjs.com/package/babel-plugin-import-directory
https://www.npmjs.com/package/babel-plugin-wildcard

This PR adds an option to early exit if a directory exists, and does not resolve the actual file.
